### PR TITLE
Adicionar melhorias de layout para a versão desktop e mobile

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -43,6 +43,10 @@
     .grid {
       grid-template-columns: 200px 200px;
     }
+
+    .footer-col {
+      width: 100%;
+    }
 }
 
 @media only screen and (max-width: 320px) {

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -18,6 +18,17 @@
   height: 56px;
 }
 
+@media only screen and (min-width: 601px) {
+  .site-nav {
+    line-height: normal;
+  }
+  
+    .site-nav .page-link {
+      padding: 24px 0;
+      display: inline-block;
+    }
+}
+
 .footer-col-1 {
   width: -webkit-calc(25% - (#{$spacing-unit} / 2));
   width:         calc(25% - (#{$spacing-unit} / 2));
@@ -33,6 +44,12 @@
   width:         calc(45% - (#{$spacing-unit} / 2));
 }
 
+@media only screen and (max-width: 600px) {
+  .footer-col {
+    width: 100%;
+  }
+}
+
 .grid {
     display: grid;
     grid-template-columns: 200px 200px 200px;
@@ -42,10 +59,6 @@
 @media only screen and (max-width: 600px) {
     .grid {
       grid-template-columns: 200px 200px;
-    }
-
-    .footer-col {
-      width: 100%;
     }
 }
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -29,6 +29,12 @@
     }
 }
 
+@media only screen and (max-width: 600px) {
+  .site-nav {
+    top: 17px;
+  }
+}
+
 .footer-col-1 {
   width: -webkit-calc(25% - (#{$spacing-unit} / 2));
   width:         calc(25% - (#{$spacing-unit} / 2));


### PR DESCRIPTION
## 1. Corrigir quebra do rodapé no mobile

**Antes**:

![Captura de Tela 2023-04-17 às 02 43 02](https://user-images.githubusercontent.com/20229434/232393117-7b7e8ddd-b7f9-4986-8d96-423a164aa7d1.png)

**Depois**:

![Captura de Tela 2023-04-17 às 02 43 36](https://user-images.githubusercontent.com/20229434/232393200-5a8b755e-7523-4b70-b3f6-836efac4b3da.png)


## 2. Alinhar os itens do menu verticalmente e aumentar área clicável

**Antes**: 

![Captura de Tela 2023-04-17 às 02 45 40](https://user-images.githubusercontent.com/20229434/232393535-ca41049b-4645-40e7-832d-9c5dcbd21f82.png)

**Depois**:

![Captura de Tela 2023-04-17 às 02 46 05](https://user-images.githubusercontent.com/20229434/232393593-e24363df-798e-4b06-8d84-cedd49be45ad.png)


## 3. Alinhar o ícone do menu verticalmente no mobile

**Antes**:

![Captura de Tela 2023-04-17 às 02 47 24](https://user-images.githubusercontent.com/20229434/232393792-45ee214e-0919-4243-96cf-33258e091d27.png)

**Depois**:

![Captura de Tela 2023-04-17 às 02 47 49](https://user-images.githubusercontent.com/20229434/232393868-64599c7c-a2de-4d48-a63c-1f5f511a529c.png)

